### PR TITLE
Submatrix Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ if (DHB_TEST)
     test/matrix.cpp
     test/vec.cpp
     test/block.cpp
+    test/submatrix.cpp
   )
 
   target_link_libraries(dhb_test PRIVATE dhb Catch2::Catch2WithMain OpenMP::OpenMP_CXX stdc++fs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(public_headers
   include/dhb/graph.h
   include/dhb/integer_log2.h
   include/dhb/vec.h
+  include/dhb/submatrix.h
 )
 
 target_sources(${PROJECT_NAME}

--- a/include/dhb/submatrix.h
+++ b/include/dhb/submatrix.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <dhb/dynamic_hashed_blocks.h>
+
+#include <algorithm>
+
+namespace dhb {
+
+using SubmatrixSet = std::vector<Vertex>;
+
+template <typename E> class Submatrix {
+  public:
+    friend void swap(Submatrix<E>& sub_a, Submatrix<E>& sub_b) noexcept {
+        using std::swap;
+        swap(sub_a.m_matrix, sub_b.m_matrix);
+        swap(sub_a.m_set, sub_b.m_set);
+    }
+
+    Submatrix() = delete;
+
+    ~Submatrix() = default;
+
+    Submatrix(Matrix<E>& matrix) : m_matrix(matrix) {}
+
+    Submatrix(Submatrix<E> const& other) : m_matrix(other.m_matrix), m_set(other.m_set) {}
+
+    Submatrix<E>(Submatrix<E>&& other) noexcept : m_matrix(other.m_matrix), m_set() {
+        m_set = other.m_set;
+
+        other.m_set.clear();
+    }
+
+    Submatrix<E>& operator=(Submatrix<E>& other) {
+        if (this != &other) {
+            m_set.resize(other.size());
+            std::copy(std::begin(other.m_set), std::end(other.m_set), m_set);
+
+            if (m_matrix != other.m_matrix) {
+                m_matrix = other.m_matrix;
+            }
+        }
+
+        return *this;
+    }
+
+    Submatrix<E>& operator=(Submatrix<E>&& other) {
+        if (this != &other) {
+            m_set = std::move(other.m_set);
+
+            if (&m_matrix != &other.m_matrix) {
+                m_matrix = other.m_matrix;
+            }
+        }
+
+        return *this;
+    }
+
+    Submatrix(Matrix<E>& matrix, Vertex const begin, Vertex const end) : m_matrix(matrix) {
+        extend_set(begin, end);
+    }
+
+    Submatrix(Matrix<E>& matrix, SubmatrixSet const& set) : m_matrix(matrix), m_set(set) {}
+
+    Submatrix(Matrix<E>& matrix, SubmatrixSet&& set) : m_matrix(matrix), m_set(std::move(set)) {}
+
+    void extend_set(Vertex const begin, Vertex const end) {
+        Vertex const actual_begin = [&](Vertex const begin) {
+            Vertex new_begin = begin;
+            std::for_each(std::begin(m_set), std::end(m_set), [&](Vertex v) {
+                if (v > new_begin) {
+                    new_begin = v;
+                    return;
+                }
+            });
+            return new_begin;
+        }(begin);
+
+        for (Vertex vertex = actual_begin; vertex < end; ++vertex) {
+            m_set.push_back(vertex);
+        }
+    }
+
+    template <typename F> void for_neighbors_node(Vertex const v, F&& handle) const {
+        m_matrix.for_neighbors_node(v, std::move(handle));
+    }
+
+    template <typename F> void for_nodes(F&& handle) const {
+        std::for_each(std::begin(m_set), std::end(m_set), handle);
+    }
+
+    typename Matrix<E>::NeighborView neighbors(Vertex const u) { return m_matrix.neighbors(u); }
+
+    typename Matrix<E>::ConstNeighborView neighbors(Vertex const u) const {
+        return typename Matrix<E>::ConstNeighborView{&m_matrix, u};
+    }
+
+    Vertex vertices_count() const { return m_set.size(); }
+
+    unsigned long edges_count() const {
+        return std::accumulate(
+            std::cbegin(m_set), std::end(m_set), 0u,
+            [this](unsigned long sum, Vertex const v) { return sum + m_matrix.degree(v); });
+    }
+
+    Vertex degree(Vertex const v) const { return m_matrix.degree(v); }
+
+    SubmatrixSet const& set() const { return m_set; }
+
+    Matrix<E>& matrix() { return m_matrix; }
+
+    Matrix<E> const& matrix() const { return m_matrix; }
+
+  private:
+    Matrix<E>& m_matrix;
+    SubmatrixSet m_set;
+};
+
+template <typename E> bool operator==(Submatrix<E> const& a, Submatrix<E> const& b) {
+    if (a.set() != b.set() || &a.matrix() != &b.matrix()) {
+        return false;
+    }
+
+    return true;
+}
+
+template <typename E> bool operator!=(Submatrix<E> const& a, Submatrix<E> const& b) {
+    return !(a == b);
+}
+
+} // namespace dhb

--- a/test/submatrix.cpp
+++ b/test/submatrix.cpp
@@ -1,0 +1,165 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <dhb/submatrix.h>
+
+using namespace dhb;
+using ED = dhb::EdgeData;
+using Tar = dhb::Target;
+
+class TestMatrix {
+  public:
+    TestMatrix() {
+        // Matrix A 3x3:
+        // [  1 | 3 | 0 ]
+        // [  4 | 5 | 8 ]
+        // [ 13 | 4 | 0 ]
+        // clang-format off
+        dhb::Edges edges_a = { 
+            {0, Tar{0, ED{1.0}}},  {0, Tar{1, ED{3.0}}}, {0, Tar{2, ED{0.0}}},
+            {1, Tar{0, ED{4.0}}},  {1, Tar{1, ED{5.0}}}, {1, Tar{2, ED{8.0}}},
+            {2, Tar{0, ED{13.0}}}, {2, Tar{1, ED{4.0}}}, {2, Tar{2, ED{0.0}}},
+        };
+        // clang-format on
+
+        a = dhb::Matrix<dhb::EdgeData>(std::move(edges_a));
+    }
+
+  protected:
+    dhb::Matrix<dhb::EdgeData> a;
+};
+
+TEST_CASE_METHOD(TestMatrix, "construct with matrix", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> a_sub(a);
+
+    CHECK(a_sub.edges_count() == 0);
+    CHECK(a_sub.set().size() == 0);
+    CHECK(&a_sub.matrix() == &a);
+}
+
+TEST_CASE_METHOD(TestMatrix, "construct with matrix, begin, and end vertex", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> a_sub(a, 0, a.vertices_count());
+
+    CHECK(a_sub.edges_count() == 9);
+    CHECK(a_sub.set().size() == 3);
+    CHECK(&a_sub.matrix() == &a);
+}
+
+TEST_CASE_METHOD(TestMatrix, "extend irregular", "[extend_set]") {
+    dhb::Submatrix<dhb::EdgeData> a_sub(a, 0, 1);
+    CHECK(a_sub.set()[0] == 0);
+    CHECK(a_sub.edges_count() == 3);
+
+    a_sub.extend_set(2, 3);
+
+    CHECK(a_sub.edges_count() == 6);
+    CHECK(a_sub.set()[0] == 0);
+    CHECK(a_sub.set()[1] == 2);
+}
+
+TEST_CASE_METHOD(TestMatrix, "construct with SubmatrixSet", "[construction]") {
+    dhb::SubmatrixSet set{0, 1};
+    Vertex const set_size = set.size();
+
+    dhb::Submatrix<dhb::EdgeData> a_sub(a, std::move(set));
+
+    CHECK(a_sub.edges_count() == 6);
+    CHECK(a_sub.set().size() == set_size);
+    CHECK(&a_sub.matrix() == &a);
+}
+
+TEST_CASE_METHOD(TestMatrix, "copy constructor", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+    dhb::Submatrix<dhb::EdgeData> sub_a_copy(sub_a);
+
+    CHECK(sub_a.set() == sub_a_copy.set());
+    CHECK(&sub_a.matrix() == &sub_a_copy.matrix());
+}
+
+TEST_CASE_METHOD(TestMatrix, "move constructor", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a_moved(a, 0, a.vertices_count());
+    dhb::Submatrix<dhb::EdgeData> sub_a_copy(sub_a_moved);
+    dhb::Submatrix<dhb::EdgeData> sub_a(std::move(sub_a_moved));
+
+    CHECK(&sub_a.matrix() == &sub_a_copy.matrix());
+    CHECK(sub_a.set() == sub_a_copy.set());
+}
+
+TEST_CASE_METHOD(TestMatrix, "copy assignment constructor", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+    dhb::Submatrix<dhb::EdgeData> sub_a_copy = sub_a;
+
+    CHECK(sub_a.set() == sub_a_copy.set());
+    CHECK(&sub_a.matrix() == &sub_a_copy.matrix());
+}
+
+TEST_CASE_METHOD(TestMatrix, "move assignment constructor", "[construction]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a_moved(a, 0, a.vertices_count());
+    dhb::Submatrix<dhb::EdgeData> sub_a_copy(sub_a_moved);
+    dhb::Submatrix<dhb::EdgeData> sub_a = std::move(sub_a_moved);
+
+    CHECK(sub_a.set() == sub_a_copy.set());
+    CHECK(&sub_a.matrix() == &sub_a_copy.matrix());
+}
+
+TEST_CASE_METHOD(TestMatrix, "operator==", "[comparison]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+    dhb::Submatrix<dhb::EdgeData> sub_a_copy = sub_a;
+
+    CHECK(sub_a == sub_a_copy);
+}
+
+TEST_CASE_METHOD(TestMatrix, "operator!=", "[comparison]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+    REQUIRE(sub_a.vertices_count() == 3);
+    dhb::Submatrix<dhb::EdgeData> sub_b(a, 0, 2);
+    REQUIRE(sub_b.vertices_count() == 2);
+
+    CHECK(sub_a != sub_b);
+}
+
+TEST_CASE_METHOD(TestMatrix, "for_neighbors_node()", "[for_neighbors_node]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+    std::vector<bool> active_nodes(3, false);
+
+    sub_a.for_neighbors_node(0, [&](dhb::Vertex const v) { active_nodes[v] = true; });
+
+    CHECK(active_nodes[0]);
+    CHECK(active_nodes[1]);
+    CHECK(active_nodes[2]);
+}
+
+TEST_CASE_METHOD(TestMatrix, "neighbors(u)", "[neighbors]") {
+    dhb::Submatrix<dhb::EdgeData> sub_a(a, 0, a.vertices_count());
+
+    CHECK(sub_a.neighbors(0).iterator_to(2)->data().weight ==
+          a.neighbors(0).iterator_to(2)->data().weight);
+}
+
+TEST_CASE_METHOD(TestMatrix, "vector of submatrices", "[std::vector]") {
+    std::vector<dhb::Submatrix<dhb::EdgeData>> submatrices(2, a);
+    REQUIRE(submatrices.size() == 2);
+
+    CHECK(submatrices[0].edges_count() == 0);
+    CHECK(submatrices[1].edges_count() == 0);
+
+    CHECK(submatrices[0].set().size() == 0);
+    CHECK(submatrices[1].set().size() == 0);
+}
+
+TEST_CASE_METHOD(TestMatrix, "vector of submatrices using function initialisation",
+                 "[lambda][init]") {
+    std::vector<dhb::Submatrix<dhb::EdgeData>> submatrices = [&]() {
+        std::vector<dhb::Submatrix<dhb::EdgeData>> submatrices(2, a);
+        submatrices[0].extend_set(0, 2);
+        submatrices[1].extend_set(1, 3);
+        return submatrices;
+    }();
+
+    REQUIRE(submatrices.size() == 2);
+
+    CHECK(submatrices[0].edges_count() == 6);
+    CHECK(submatrices[1].edges_count() == 6);
+
+    CHECK(submatrices[0].set().size() == 2);
+    CHECK(submatrices[1].set().size() == 2);
+}


### PR DESCRIPTION
This is the outcome of a current project where a submatrix type is needed. It should mainly serve as a convenience class to not keep track of a submatrix set oneself. In addition, this class can be used as a generic type to functions taking either a `Matrix` or a `Submatrix`. Indeed this requires one layer of indirection when using a `Submatrix` object.

Still to do:
- additional tests
- check if Matrix/Submatrix API is sufficient for now