### PR TITLE
Concurrency Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(dhb VERSION 1.0.0)
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if (DHB_TEST)
   add_executable(dhb_test
     test/graph_io.h
     test/graph_io.cpp
-    test/matrix.cpp
+    test/matrix_test.cpp
     test/vec.cpp
     test/block.cpp
     test/submatrix.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(WITH_DHB_SYSTEM_ALLOCATOR "Use DHB System Allocator" OFF)
 option(WITH_DHB_64BIT_IDS "Use 64 bit IDs." OFF)
 
-# different ways of sorting edges when inserting in concurrently
-set(WITH_DHB_SCATTER "counting" CACHE STRING "Parallelization method")
-
 add_library(dhb STATIC)
 
 set(public_headers
@@ -35,6 +32,7 @@ set(public_headers
 
 target_sources(${PROJECT_NAME}
   PRIVATE
+    include/dhb/hash_tools.h
     src/buckets.cpp
     src/dynamic_hashed_blocks.cpp
     src/graph.cpp
@@ -53,22 +51,6 @@ if (WITH_DHB_64BIT_IDS)
   target_compile_definitions(dhb PUBLIC -DDHB_64BIT_IDS)
 else()
   MESSAGE(STATUS "Using 32 bit IDs.")
-endif()
-
-if (WITH_DHB_SCATTER STREQUAL "twophase")
-	MESSAGE(STATUS "Using scatter in two phases.")
-	target_compile_definitions(dhb PUBLIC -DDHB_SCATTER_TWOPHASE)
-elseif (WITH_DHB_SCATTER STREQUAL "counting")
-	MESSAGE(STATUS "Using scatter counting.")
-	target_compile_definitions(dhb PUBLIC -DDHB_SCATTER_COUNTING)
-elseif (WITH_DHB_SCATTER STREQUAL "sorting")
-	MESSAGE(STATUS "Using scatter sorting.")
-	target_compile_definitions(dhb PUBLIC -DDHB_SCATTER_SORTING)
-elseif (WITH_DHB_SCATTER STREQUAL "darts")
-	MESSAGE(STATUS "Using scatter darts.")
-	target_compile_definitions(dhb PUBLIC -DDHB_SCATTER_DARTS)
-else()
-	message(FATAL_ERROR "Illegal setting for WITH_DHB_SCATTER")
 endif()
 
 set_property(TARGET dhb PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -109,7 +91,6 @@ set_target_properties(${PROJECT_NAME}::${PROJECT_NAME} PROPERTIES
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${public_headers}")
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
-
 
 # ===================================
 # Make a Configuration Package

--- a/include/dhb/batcher.h
+++ b/include/dhb/batcher.h
@@ -1,18 +1,16 @@
 #pragma once
 
+#include <dhb/block.h>
 #include <dhb/graph.h>
+#include <dhb/hash_tools.h>
+
+#include <omp.h>
 
 #include <algorithm>
-#include <assert.h>
-#include <omp.h>
+#include <cassert>
 #include <stdexcept>
 #include <thread>
 #include <tuple>
-
-#include <atomic>
-#include <dhb/block.h>
-
-
 
 namespace dhb {
 
@@ -57,10 +55,18 @@ std::tuple<EdgeIt, EdgeIt> thread_batch(EdgeIt batch_begin, EdgeIt batch_end,
     return {start, end};
 }
 
+template <typename key_t> key_t key_to_thread(key_t k, uint32_t t_count) {
+    if constexpr (std::is_same<key_t, uint32_t>()) {
+        return reduce(hash32(k), t_count);
+    } else {
+        return hash64(k) % t_count;
+    }
+}
+
 template <typename T> class BatchParallelizer {
   public:
-    template <typename Iterator, typename K, typename F>
-    void operator()(Iterator begin, Iterator end, K key, F func) {
+    template <typename Iterator, typename K, typename Cmp, typename F>
+    void operator()(Iterator begin, Iterator end, K key, Cmp cmp, F func) {
         int const t_count = omp_get_max_threads();
         size_t const n = end - begin;
         if (t_count == 1 || n < t_count) {
@@ -69,8 +75,6 @@ template <typename T> class BatchParallelizer {
             return;
         }
 
-#if defined(DHB_SCATTER_SORTING)
-        auto cmp = [](Edge u, Edge v) { return u.source < v.source; };
         std::sort(begin, end, cmp);
 #pragma omp parallel shared(begin, end)
         {
@@ -80,82 +84,17 @@ template <typename T> class BatchParallelizer {
                 func(*it);
             }
         }
-#elif defined(DHB_SCATTER_DARTS)
-        constexpr auto empty_cell = static_cast<unsigned int>(-1);
+    }
 
-        // Number of slots per thread.
-        // Slightly larger than the batch size per thread.
-        auto s = 1 << (integer_log2_ceil((n + t_count - 1) / t_count) + 2);
-
-        m_batch_slots.resize(s * t_count);
-        std::fill(m_batch_slots.begin(), m_batch_slots.end(), empty_cell);
-        m_batch_dispatched.resize(n);
-        std::fill(m_batch_dispatched.begin(), m_batch_dispatched.end(), 0);
-
-        auto slots = m_batch_slots.data();
-        auto dispatched = m_batch_dispatched.data();
-
-        std::atomic<size_t> n_done{0};
-
-#pragma omp parallel num_threads(t_count)
-        {
-            auto t = omp_get_thread_num();
-            assert(omp_get_num_threads() == t_count);
-            auto n_per_thread = n / t_count;
-
-            std::minstd_rand prng{m_prng_seed + t};
-            std::uniform_int_distribution<int> distrib{0, s - 1};
-
-            int r;
-            for (r = 1;; ++r) {
-                auto i_begin = t * n_per_thread;
-                auto i_end = i_begin + n_per_thread;
-                if (t == t_count - 1)
-                    i_end = n;
-                for (size_t i = i_begin; i < i_end; ++i) {
-                    if (__atomic_load_n(&dispatched[i], __ATOMIC_RELAXED))
-                        continue;
-                    auto k = key(*(begin + i));
-                    auto d = hash_node(k) % t_count;
-                    auto j = distrib(prng);
-                    __atomic_store_n(&slots[d * s + j], i, __ATOMIC_RELAXED);
-                }
-
-                size_t n_now = 0;
-                for (size_t j = t * s; j < (t + 1) * s; ++j) {
-                    auto i = __atomic_load_n(&slots[j], __ATOMIC_RELAXED);
-                    if (i == empty_cell)
-                        continue;
-                    if (dispatched[i])
-                        continue;
-                    func(*(begin + i));
-                    __atomic_store_n(&dispatched[i], 1, __ATOMIC_RELAXED);
-                    __atomic_store_n(&slots[j], empty_cell, __ATOMIC_RELAXED);
-                    ++n_now;
-                }
-
-                if (n_now)
-                    n_done.fetch_add(n_now, std::memory_order_relaxed);
-                if (n_done.load(std::memory_order_relaxed) == n)
-                    break;
-            }
+    template <typename Iterator, typename K, typename Cmp, typename F>
+    void apply(Iterator begin, Iterator end, K key, Cmp cmp, F func) {
+        int const t_count = omp_get_max_threads();
+        size_t const n = end - begin;
+        if (t_count == 1 || n < t_count) {
+            for (auto it = begin; it != end; ++it)
+                func(*it);
+            return;
         }
-
-        m_prng_seed += t_count;
-#elif defined(DHB_SCATTER_TWOPHASE)
-        auto key_to_thread = [](unsigned int k, unsigned int t_count) -> unsigned int {
-            auto hash = [](unsigned int x) -> unsigned int {
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = (x >> 16) ^ x;
-                return x;
-            };
-
-            // First, hash the key to get a value that is scattered evenly in [0, 2^32).
-            // For such values, the multiplication + shift yields an almost fair map,
-            // see https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/.
-            return (static_cast<uint64_t>(hash(k)) * static_cast<uint64_t>(t_count)) >> 32;
-        };
 
         m_batch_counts.resize((t_count + 1) * t_count);
         m_batch_slots.resize(n);
@@ -165,7 +104,7 @@ template <typename T> class BatchParallelizer {
             auto t = omp_get_thread_num();
             assert(omp_get_num_threads() == t_count);
 
-            auto counts_of_thread = [&](int ct) -> unsigned int* {
+            auto counts_of_thread = [&](int ct) -> uint64_t* {
                 return &m_batch_counts[ct * (t_count + 1)];
             };
 
@@ -176,10 +115,10 @@ template <typename T> class BatchParallelizer {
                 i_end = n;
 
             // First, perform a local counting sort to sort updates according to associated threads.
-
             auto t_counts = counts_of_thread(t);
-            for (int at = 0; at < t_count; ++at)
+            for (size_t at = 0; at < t_count; ++at) {
                 t_counts[at] = 0;
+            }
 
             for (size_t i = i_begin; i < i_end; ++i) {
                 auto k = key(*(begin + i));
@@ -187,7 +126,7 @@ template <typename T> class BatchParallelizer {
                 ++t_counts[at];
             }
 
-            unsigned int psum = 0;
+            uint64_t psum = 0;
             for (int at = 0; at < t_count; ++at) {
                 psum += t_counts[at];
                 t_counts[at] = i_begin + psum;
@@ -208,7 +147,7 @@ template <typename T> class BatchParallelizer {
 
 #pragma omp barrier
 
-            unsigned int local_count = 0;
+            uint64_t local_count = 0;
             for (int ot = 0; ot < t_count; ++ot) {
                 auto ot_counts = counts_of_thread(ot);
                 auto j_begin = ot_counts[t];
@@ -221,31 +160,14 @@ template <typename T> class BatchParallelizer {
                 local_count += j_end - j_begin;
             }
         }
-#else
-        throw std::runtime_error("DHB was compiled without support for parallel updates");
-#endif
     }
 
     template <typename Iterator, typename K> void distribute(Iterator begin, Iterator end, K key) {
         int const t_count = omp_get_num_threads();
         size_t const n = end - begin;
-        if (t_count == 1 || n < t_count)
+        if (t_count == 1 || n < t_count) {
             return;
-
-#if defined(DHB_SCATTER_TWOPHASE)
-        auto key_to_thread = [](unsigned int k, unsigned int t_count) -> unsigned int {
-            auto hash = [](unsigned int x) -> unsigned int {
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = (x >> 16) ^ x;
-                return x;
-            };
-
-            // First, hash the key to get a value that is scattered evenly in [0, 2^32).
-            // For such values, the multiplication + shift yields an almost fair map,
-            // see https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/.
-            return (static_cast<uint64_t>(hash(k)) * static_cast<uint64_t>(t_count)) >> 32;
-        };
+        }
 
 #pragma omp single
         {
@@ -255,7 +177,7 @@ template <typename T> class BatchParallelizer {
 
         auto t = omp_get_thread_num();
 
-        auto counts_of_thread = [&](int ct) -> unsigned int* {
+        auto counts_of_thread = [&](int ct) -> uint64_t* {
             return &m_batch_counts[ct * (t_count + 1)];
         };
 
@@ -277,7 +199,7 @@ template <typename T> class BatchParallelizer {
             ++t_counts[at];
         }
 
-        unsigned int psum = 0;
+        uint64_t psum = 0;
         for (int at = 0; at < t_count; ++at) {
             psum += t_counts[at];
             t_counts[at] = i_begin + psum;
@@ -296,101 +218,6 @@ template <typename T> class BatchParallelizer {
 
         // Now, let each thread collect its updates.
 #pragma omp barrier
-
-#elif defined(DHB_SCATTER_COUNTING)
-        auto key_to_thread = [](unsigned int k, unsigned int t_count) -> unsigned int {
-            // More on this xor shift hash function can be found at:
-            // https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
-            auto hash = [](uint32_t x) -> uint32_t {
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = ((x >> 16) ^ x) * 0x45d9f3b;
-                x = (x >> 16) ^ x;
-                return x;
-            };
-
-            // We are using a fast alternative to the modulo reduction from
-            // Daniel Lemire's blog. See:
-            // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction First,
-            // hash the key to get a value that is scattered evenly in [0, 2^32). For such values,
-            // the multiplication + shift yields an almost fair map.
-            return (static_cast<uint64_t>(hash(k)) * static_cast<uint64_t>(t_count)) >> 32;
-        };
-
-#pragma omp single
-        // We start with an input buffer which is the batch that is to be
-        // operated on (distribute workload). In order to operate in fair balance
-        // we need to distribute the objects of the batch to our thread pool.
-        // Therefore, each thread first identifies the objects that have to be
-        // moved around using a hash function for the objects key (e.g. an edge
-        // source). Second, an additional out buffer is allocated, offsets and
-        // objects to be moved computed. Finally, all objects are moved to that out
-        // buffer then ready to be used by the map() function.
-
-        {
-            m_batch_counts.resize((t_count + 1) * t_count);
-            m_out.resize(t_count);
-            m_wp.resize(t_count);
-        }
-
-        int const t_id = omp_get_thread_num();
-
-        auto counts_of_thread = [&](int for_t_id) -> unsigned int* {
-            return &m_batch_counts[for_t_id * (t_count + 1)];
-        };
-
-        auto n_per_thread = n / t_count;
-        ptrdiff_t i_begin = t_id * n_per_thread;
-        ptrdiff_t i_end = i_begin + n_per_thread;
-        if (t_id == t_count - 1) {
-            i_end = n;
-        }
-
-        // Determine send counts.
-        auto t_counts = counts_of_thread(t_id);
-        std::fill_n(std::begin(t_counts), t_count, 0);
-
-        for (ptrdiff_t i = i_begin; i < i_end; ++i) {
-            auto it = begin + i;
-            auto k = key(*it);
-            auto at = key_to_thread(k, t_count);
-            ++t_counts[at];
-        }
-
-#pragma omp barrier
-        // Do a prefix sum over the send count *to* the current thread.
-
-        unsigned int psum = 0;
-        for (int rt = 0; rt < t_count; ++rt) {
-            auto rt_counts = counts_of_thread(rt);
-            auto c = rt_counts[t_id];
-            rt_counts[t_id] = psum;
-            psum += c;
-        }
-
-        m_out[t_id].resize(psum);
-
-#pragma omp barrier
-        // We have determined which objects have to be moved to which thread buffers.
-        // Now it is time to move the objects to the thread buffers. Therefore, we
-        // use m_wp: an array of pointers for each thread storing the current
-        // pointer to the out array to which to write the object.
-
-        m_wp[t_id].resize(t_count);
-        for (int at = 0; at < t_count; ++at)
-            m_wp[t_id][at] = m_out[at].data() + t_counts[at];
-        auto wp_ptr = m_wp[t_id].data();
-
-        for (ptrdiff_t i = i_begin; i < i_end; ++i) {
-            auto it = begin + i;
-            auto k = key(*it);
-            auto at = key_to_thread(k, t_count);
-            *(wp_ptr[at]++) = *it;
-        }
-
-#pragma omp barrier
-#else
-        throw std::runtime_error("DHB was compiled without support for parallel updates");
-#endif
     }
 
     template <typename Iterator, typename F> void map(Iterator begin, Iterator end, F func) {
@@ -406,14 +233,14 @@ template <typename T> class BatchParallelizer {
             }
             return;
         }
-#if defined(DHB_SCATTER_TWOPHASE)
+
         auto t = omp_get_thread_num();
 
-        auto counts_of_thread = [&](int ct) -> unsigned int* {
+        auto counts_of_thread = [&](int ct) -> uint64_t* {
             return &m_batch_counts[ct * (t_count + 1)];
         };
 
-        unsigned int local_count = 0;
+        uint64_t local_count = 0;
         for (int ot = 0; ot < t_count; ++ot) {
             auto ot_counts = counts_of_thread(ot);
             auto j_begin = ot_counts[t];
@@ -425,29 +252,11 @@ template <typename T> class BatchParallelizer {
             }
             local_count += j_end - j_begin;
         }
-#elif defined(DHB_SCATTER_COUNTING)
-        auto t = omp_get_thread_num();
-
-        for (auto& elem : m_out[t])
-            func(elem);
-#else
-        throw std::runtime_error("DHB was compiled without support for parallel updates");
-#endif
     }
 
   private:
-#if defined(DHB_SCATTER_DARTS)
-    unsigned int m_prng_seed = 0;
-    std::vector<unsigned int> m_batch_slots;
-    std::vector<char> m_batch_dispatched;
-#elif defined(DHB_SCATTER_TWOPHASE)
-    std::vector<unsigned int> m_batch_counts;
-    std::vector<unsigned int> m_batch_slots;
-#elif defined(DHB_SCATTER_COUNTING)
-    std::vector<unsigned int> m_batch_counts;
-    std::vector<std::vector<T>> m_out;
-    std::vector<std::vector<T*>> m_wp;
-#endif
+    std::vector<uint64_t> m_batch_counts;
+    std::vector<uint64_t> m_batch_slots;
 };
 
 } // namespace dhb

--- a/include/dhb/hash_tools.h
+++ b/include/dhb/hash_tools.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+
+namespace dhb {
+
+// Fast modulo reduction
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+inline uint32_t reduce(uint32_t x, uint32_t operand) {
+    return uint32_t(uint64_t(x) * uint64_t(operand) >> 32);
+}
+
+inline uint32_t hash32(uint32_t x) {
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    return x;
+}
+
+// Thanks to David Stafford for his further research on Austin Appleby's
+// MurmurHash3 specifically for input values with low entropy such as it is the
+// case for our dynamic hashtable that shall store vertex ids - and are more
+// close to counting numbers than random ones.
+//
+// The one we are using here is Mix13.
+//
+// Please go to
+// http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html for
+// further reading.
+//
+// Also thanks to Thomas Mueller for his answer on good integer hashing:
+// https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
+//
+// The final function definition comes from Sebastiano Vigna:
+// https://xorshift.di.unimi.it/splitmix64.c
+inline uint64_t hash64(uint64_t x) {
+    constexpr uint64_t op_a = 0xbf58476d1ce4e5b9;
+    constexpr uint64_t op_b = 0x94d049bb133111eb;
+
+    x = (x ^ (x >> 30)) * op_a;
+    x = (x ^ (x >> 27)) * op_b;
+    x = x ^ (x >> 31);
+    return x;
+}
+
+} // namespace dhb

--- a/include/dhb/hash_tools.h
+++ b/include/dhb/hash_tools.h
@@ -18,8 +18,7 @@ inline uint32_t hash32(uint32_t x) {
 }
 
 // Thanks to David Stafford for his further research on Austin Appleby's
-// MurmurHash3 specifically for input values with low entropy such as it is the
-// case for our dynamic hashtable that shall store vertex ids - and are more
+// MurmurHash3 specifically for input values with low entropy which are more
 // close to counting numbers than random ones.
 //
 // The one we are using here is Mix13.

--- a/src/buckets.cpp
+++ b/src/buckets.cpp
@@ -2,6 +2,7 @@
 #include <dhb/integer_log2.h>
 
 #include <cassert>
+#include <stdexcept>
 
 namespace dhb {
 


### PR DESCRIPTION
This PR fixes an issue with the multiple concurrency options that were originally implemented in the DHB source code. None of the original strategies worked _out of the box_. Therefore, this PR reduces the set of concurrency option to a single strategy. In addition, some hash functions and edge type dependent module operations have been revised.

What's missing here is to add different test targets: one for the 32 bit the other for the 64 bit vertex and edge ID type. After a consultation with @fabratu, this will most likely be implemented using a template parameter to differ between the types instead of using a pre-processor definition as done currently. This, however, is out of the scope of this PR. 