### PR TITLE
Batcher requires a function to get the source of an edge.

### DIFF
--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -203,8 +203,10 @@ TEST_CASE("Matrix") {
         auto cmp = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key = [](Edge e) { return e.source; };
         auto fun = [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
         BatchParallelizer<Edge> par;
-        par(new_edges.begin(), new_edges.end(), std::move(key), std::move(cmp), std::move(fun));
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key),
+            std::move(cmp), std::move(fun));
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
         CHECK(nv.degree() == 5);
@@ -234,9 +236,11 @@ TEST_CASE("Matrix") {
                 std::get<0>(insertion_result)->data() = e.target.data;
             }
         };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
 
         BatchParallelizer<Edge> par;
-        par(new_edges.begin(), new_edges.end(), std::move(key), std::move(cmp), std::move(fun));
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key),
+            std::move(cmp), std::move(fun));
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
         CHECK(nv.degree() == 5);
@@ -260,8 +264,9 @@ TEST_CASE("Matrix") {
         auto cmp = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key = [](Edge e) { return e.source; };
         auto fun = [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
         BatchParallelizer<Edge> par;
-        par(edges.begin(), edges.end(), std::move(key), std::move(cmp), fun);
+        par(edges.begin(), edges.end(), std::move(get_edge_f), std::move(key), std::move(cmp), fun);
 
         Edge e89_14{89, Target{14, EdgeData{10.f, 450}}};
         Edge e89_8{89, Target{8, EdgeData{10.f, 451}}};
@@ -270,7 +275,8 @@ TEST_CASE("Matrix") {
 
         auto cmp2 = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key2 = [](Edge e) { return e.source; };
-        par(new_edges.begin(), new_edges.end(), std::move(key2), std::move(cmp2),
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key2),
+            std::move(cmp2),
             [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); });
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
@@ -292,6 +298,7 @@ TEST_CASE("Matrix") {
         auto cmp = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key = [](Edge e) { return e.source; };
         auto fun = [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
         BatchParallelizer<Edge> par;
 
         par.apply(edges.begin(), edges.end(), std::move(key), std::move(cmp), fun);
@@ -304,7 +311,8 @@ TEST_CASE("Matrix") {
         auto cmp2 = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key2 = [](Edge e) { return e.source; };
 
-        par(new_edges.begin(), new_edges.end(), std::move(key2), std::move(cmp2),
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key2),
+            std::move(cmp2),
             [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); });
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
@@ -326,6 +334,7 @@ TEST_CASE("Matrix") {
         auto cmp = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key = [](Edge e) { return e.source; };
         auto fun = [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
         BatchParallelizer<Edge> par;
 
         std::vector<unsigned int> degrees(m.vertices_count());
@@ -353,7 +362,8 @@ TEST_CASE("Matrix") {
         auto cmp2 = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key2 = [](Edge e) { return e.source; };
 
-        par(new_edges.begin(), new_edges.end(), std::move(key2), std::move(cmp2),
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key2),
+            std::move(cmp2),
             [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); });
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
@@ -374,9 +384,10 @@ TEST_CASE("Matrix") {
 
         auto cmp = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key = [](Edge e) { return e.source; };
+        auto get_edge_f = [](Edge const& e) { return e.source; };
 
         BatchParallelizer<Edge> par;
-        par(edges.begin(), edges.end(), std::move(key), std::move(cmp),
+        par(edges.begin(), edges.end(), std::move(get_edge_f), std::move(key), std::move(cmp),
             [&](Edge e) { m.neighbors(e.source).insert(e.target.vertex, e.target.data); });
 
         Edge e89_14{89, Target{14, EdgeData{10.f, 450}}};
@@ -389,13 +400,14 @@ TEST_CASE("Matrix") {
         auto cmp2 = [](Edge const& a, Edge const& b) { return a.source < b.source; };
         auto key2 = [](Edge e) { return e.source; };
 
-        par(new_edges.begin(), new_edges.end(), std::move(key), std::move(cmp), [&](Edge e) {
-            std::tuple<dhb::BlockState<dhb::EdgeData>::iterator, bool> insertion_result =
-                m.neighbors(e.source).insert(e.target.vertex, e.target.data);
-            if (!std::get<1>(insertion_result)) {
-                std::get<0>(insertion_result)->data() = e.target.data;
-            }
-        });
+        par(new_edges.begin(), new_edges.end(), std::move(get_edge_f), std::move(key),
+            std::move(cmp), [&](Edge e) {
+                std::tuple<dhb::BlockState<dhb::EdgeData>::iterator, bool> insertion_result =
+                    m.neighbors(e.source).insert(e.target.vertex, e.target.data);
+                if (!std::get<1>(insertion_result)) {
+                    std::get<0>(insertion_result)->data() = e.target.data;
+                }
+            });
 
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
         CHECK(nv.degree() == 5);


### PR DESCRIPTION
By requiring that function (additional lambda) the batcher does not need any internal knowledge of the edge type iterating over.