### PR TITLE
Revisiting Neighbor View

### DIFF
--- a/include/dhb/block.h
+++ b/include/dhb/block.h
@@ -590,7 +590,10 @@ template <typename E> class BlockState {
 
     iterator valid_end() const { return iterator(m_entries + m_degree); }
 
+    const_iterator cvalid_end() const { return const_iterator(m_entries + m_degree); }
+
     iterator begin() { return iterator(m_entries); }
+
     const_iterator begin() const { return const_iterator(m_entries); }
 
     const_iterator cbegin() const { return const_iterator(m_entries); }

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -18,7 +18,8 @@ std::vector<Degree> degrees_from(Edges const&);
 
 template <typename E> struct Matrix {
   public:
-    struct NeighborView {
+    class NeighborView {
+      public:
         using iterator = typename BlockState<E>::iterator;
         using proxy = typename BlockState<E>::proxy;
 
@@ -65,7 +66,8 @@ template <typename E> struct Matrix {
         Vertex m_u;
     };
 
-    struct ConstNeighborView {
+    class ConstNeighborView {
+      public:
         using iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::const_proxy;
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -58,6 +58,8 @@ template <typename E> struct Matrix {
             return result;
         }
 
+        Vertex source() const { return m_u; }
+
       private:
         Matrix* m_g;
         Vertex m_u;
@@ -80,6 +82,8 @@ template <typename E> struct Matrix {
         size_t degree() { return end() - begin(); }
 
         proxy operator[](size_t i) { return *(begin() + i); }
+
+        Vertex source() const { return m_u; }
 
       private:
         const Matrix* m_g;

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -62,7 +62,7 @@ template <typename E> struct Matrix {
         Vertex source() const { return m_u; }
 
       private:
-        Matrix* m_g;
+        Matrix* const m_g;
         Vertex m_u;
     };
 
@@ -73,22 +73,22 @@ template <typename E> struct Matrix {
 
         ConstNeighborView(const Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
 
-        iterator begin() { return m_g->m_vertices[m_u].begin(); }
+        iterator begin() const { return m_g->m_vertices[m_u].begin(); }
 
-        iterator end() { return m_g->m_vertices[m_u].valid_end(); }
+        iterator end() const { return m_g->m_vertices[m_u].valid_end(); }
 
-        iterator iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) const { return m_g->m_vertices[m_u].iterator_to(v); }
 
-        bool exists(Vertex v) { return iterator_to(v) != end(); }
+        bool exists(Vertex v) const { return iterator_to(v) != end(); }
 
-        size_t degree() { return end() - begin(); }
+        size_t degree() const { return end() - begin(); }
 
         proxy operator[](size_t offset) const { return *(begin() + offset); }
 
         Vertex source() const { return m_u; }
 
       private:
-        const Matrix* m_g;
+        Matrix const* const m_g;
         Vertex m_u;
     };
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -24,28 +24,28 @@ template <typename E> struct Matrix {
         using const_iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::proxy;
 
-        NeighborView(Matrix* g, Vertex u) : m_graph{g}, m_u{u} {}
+        NeighborView(Matrix* g, Vertex u) : m_graph{g}, m_source{u} {}
 
-        iterator begin() { return m_graph->m_vertices[m_u].begin(); }
+        iterator begin() { return m_graph->m_vertices[m_source].begin(); }
 
-        const_iterator cbegin() const { return m_graph->m_vertices[m_u].cbegin(); }
+        const_iterator cbegin() const { return m_graph->m_vertices[m_source].cbegin(); }
 
-        iterator end() { return m_graph->m_vertices[m_u].valid_end(); }
+        iterator end() { return m_graph->m_vertices[m_source].valid_end(); }
 
-        const_iterator cend() const { return m_graph->m_vertices[m_u].cvalid_end(); }
+        const_iterator cend() const { return m_graph->m_vertices[m_source].cvalid_end(); }
 
-        iterator iterator_to(Vertex v) { return m_graph->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) { return m_graph->m_vertices[m_source].iterator_to(v); }
 
         bool exists(Vertex v) { return iterator_to(v) != end(); }
 
-        void clear() { m_graph->m_vertices[m_u].clear(); }
+        void clear() { m_graph->m_vertices[m_source].clear(); }
 
         size_t degree() { return end() - begin(); }
 
         proxy operator[](size_t offset) { return *(begin() + offset); }
 
         std::tuple<iterator, bool> insert(Vertex v, E ed) {
-            auto& state = m_graph->m_vertices[m_u];
+            auto& state = m_graph->m_vertices[m_source];
 
             if (!state.full())
                 return state.insert(v, ed);
@@ -55,20 +55,20 @@ template <typename E> struct Matrix {
             BlockState<E> new_block{new_bhandle, state};
             auto result = new_block.insert(v, ed);
 
-            auto old_block = std::move(m_graph->m_vertices[m_u]);
-            auto old_bhandle = m_graph->m_handles[m_u];
-            m_graph->m_vertices[m_u] = std::move(new_block);
-            m_graph->m_handles[m_u] = new_bhandle;
+            auto old_block = std::move(m_graph->m_vertices[m_source]);
+            auto old_bhandle = m_graph->m_handles[m_source];
+            m_graph->m_vertices[m_source] = std::move(new_block);
+            m_graph->m_handles[m_source] = new_bhandle;
             m_graph->m_manager->free_block(old_bhandle);
 
             return result;
         }
 
-        Vertex source() const { return m_u; }
+        Vertex source() const { return m_source; }
 
       private:
         Matrix* m_graph;
-        Vertex m_u;
+        Vertex m_source;
     };
 
     class ConstNeighborView {
@@ -76,13 +76,15 @@ template <typename E> struct Matrix {
         using iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::const_proxy;
 
-        ConstNeighborView(const Matrix* g, Vertex u) : m_graph{g}, m_u{u} {}
+        ConstNeighborView(const Matrix* g, Vertex u) : m_graph{g}, m_source{u} {}
 
-        iterator begin() const { return m_graph->m_vertices[m_u].cbegin(); }
+        iterator begin() const { return m_graph->m_vertices[m_source].cbegin(); }
 
-        iterator end() const { return m_graph->m_vertices[m_u].cvalid_end(); }
+        iterator end() const { return m_graph->m_vertices[m_source].cvalid_end(); }
 
-        iterator iterator_to(Vertex v) const { return m_graph->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) const {
+            return m_graph->m_vertices[m_source].iterator_to(v);
+        }
 
         bool exists(Vertex v) const { return iterator_to(v) != end(); }
 
@@ -90,11 +92,11 @@ template <typename E> struct Matrix {
 
         proxy operator[](size_t offset) const { return *(begin() + offset); }
 
-        Vertex source() const { return m_u; }
+        Vertex source() const { return m_source; }
 
       private:
         Matrix const* m_graph;
-        Vertex m_u;
+        Vertex m_source;
     };
 
     friend void swap(Matrix& p, Matrix& q) noexcept {

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -37,7 +37,7 @@ template <typename E> struct Matrix {
 
         size_t degree() { return end() - begin(); }
 
-        proxy operator[](size_t i) { return *(begin() + i); }
+        proxy operator[](size_t offset) { return *(begin() + offset); }
 
         std::tuple<iterator, bool> insert(Vertex v, E ed) {
             auto& state = m_g->m_vertices[m_u];
@@ -83,7 +83,7 @@ template <typename E> struct Matrix {
 
         size_t degree() { return end() - begin(); }
 
-        proxy operator[](size_t i) { return *(begin() + i); }
+        proxy operator[](size_t offset) const { return *(begin() + offset); }
 
         Vertex source() const { return m_u; }
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -67,8 +67,8 @@ template <typename E> struct Matrix {
         Vertex source() const { return m_u; }
 
       private:
-        Matrix* const m_g;
-        Vertex const m_u;
+        Matrix* m_g;
+        Vertex m_u;
     };
 
     class ConstNeighborView {
@@ -93,8 +93,8 @@ template <typename E> struct Matrix {
         Vertex source() const { return m_u; }
 
       private:
-        Matrix const* const m_g;
-        Vertex const m_u;
+        Matrix const* m_g;
+        Vertex m_u;
     };
 
     friend void swap(Matrix& p, Matrix& q) noexcept {

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -24,42 +24,42 @@ template <typename E> struct Matrix {
         using const_iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::proxy;
 
-        NeighborView(Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
+        NeighborView(Matrix* g, Vertex u) : m_graph{g}, m_u{u} {}
 
-        iterator begin() { return m_g->m_vertices[m_u].begin(); }
+        iterator begin() { return m_graph->m_vertices[m_u].begin(); }
 
-        const_iterator cbegin() const { return m_g->m_vertices[m_u].cbegin(); }
+        const_iterator cbegin() const { return m_graph->m_vertices[m_u].cbegin(); }
 
-        iterator end() { return m_g->m_vertices[m_u].valid_end(); }
+        iterator end() { return m_graph->m_vertices[m_u].valid_end(); }
 
-        const_iterator cend() const { return m_g->m_vertices[m_u].cvalid_end(); }
+        const_iterator cend() const { return m_graph->m_vertices[m_u].cvalid_end(); }
 
-        iterator iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) { return m_graph->m_vertices[m_u].iterator_to(v); }
 
         bool exists(Vertex v) { return iterator_to(v) != end(); }
 
-        void clear() { m_g->m_vertices[m_u].clear(); }
+        void clear() { m_graph->m_vertices[m_u].clear(); }
 
         size_t degree() { return end() - begin(); }
 
         proxy operator[](size_t offset) { return *(begin() + offset); }
 
         std::tuple<iterator, bool> insert(Vertex v, E ed) {
-            auto& state = m_g->m_vertices[m_u];
+            auto& state = m_graph->m_vertices[m_u];
 
             if (!state.full())
                 return state.insert(v, ed);
 
             // We need to reallocate the adjacency block.
-            auto new_bhandle = m_g->m_manager->allocate_block(state.bsize() + 1);
+            auto new_bhandle = m_graph->m_manager->allocate_block(state.bsize() + 1);
             BlockState<E> new_block{new_bhandle, state};
             auto result = new_block.insert(v, ed);
 
-            auto old_block = std::move(m_g->m_vertices[m_u]);
-            auto old_bhandle = m_g->m_handles[m_u];
-            m_g->m_vertices[m_u] = std::move(new_block);
-            m_g->m_handles[m_u] = new_bhandle;
-            m_g->m_manager->free_block(old_bhandle);
+            auto old_block = std::move(m_graph->m_vertices[m_u]);
+            auto old_bhandle = m_graph->m_handles[m_u];
+            m_graph->m_vertices[m_u] = std::move(new_block);
+            m_graph->m_handles[m_u] = new_bhandle;
+            m_graph->m_manager->free_block(old_bhandle);
 
             return result;
         }
@@ -67,7 +67,7 @@ template <typename E> struct Matrix {
         Vertex source() const { return m_u; }
 
       private:
-        Matrix* m_g;
+        Matrix* m_graph;
         Vertex m_u;
     };
 
@@ -76,13 +76,13 @@ template <typename E> struct Matrix {
         using iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::const_proxy;
 
-        ConstNeighborView(const Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
+        ConstNeighborView(const Matrix* g, Vertex u) : m_graph{g}, m_u{u} {}
 
-        iterator begin() const { return m_g->m_vertices[m_u].cbegin(); }
+        iterator begin() const { return m_graph->m_vertices[m_u].cbegin(); }
 
-        iterator end() const { return m_g->m_vertices[m_u].cvalid_end(); }
+        iterator end() const { return m_graph->m_vertices[m_u].cvalid_end(); }
 
-        iterator iterator_to(Vertex v) const { return m_g->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) const { return m_graph->m_vertices[m_u].iterator_to(v); }
 
         bool exists(Vertex v) const { return iterator_to(v) != end(); }
 
@@ -93,7 +93,7 @@ template <typename E> struct Matrix {
         Vertex source() const { return m_u; }
 
       private:
-        Matrix const* m_g;
+        Matrix const* m_graph;
         Vertex m_u;
     };
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -63,7 +63,7 @@ template <typename E> struct Matrix {
 
       private:
         Matrix* const m_g;
-        Vertex m_u;
+        Vertex const m_u;
     };
 
     class ConstNeighborView {
@@ -89,7 +89,7 @@ template <typename E> struct Matrix {
 
       private:
         Matrix const* const m_g;
-        Vertex m_u;
+        Vertex const m_u;
     };
 
     friend void swap(Matrix& p, Matrix& q) noexcept {

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -25,11 +25,11 @@ template <typename E> struct Matrix {
 
         NeighborView(Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
 
-        auto begin() { return m_g->m_vertices[m_u].begin(); }
+        iterator begin() { return m_g->m_vertices[m_u].begin(); }
 
-        auto end() { return m_g->m_vertices[m_u].valid_end(); }
+        iterator end() { return m_g->m_vertices[m_u].valid_end(); }
 
-        auto iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
 
         bool exists(Vertex v) { return iterator_to(v) != end(); }
 
@@ -73,11 +73,11 @@ template <typename E> struct Matrix {
 
         ConstNeighborView(const Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
 
-        auto begin() { return m_g->m_vertices[m_u].begin(); }
+        iterator begin() { return m_g->m_vertices[m_u].begin(); }
 
-        auto end() { return m_g->m_vertices[m_u].valid_end(); }
+        iterator end() { return m_g->m_vertices[m_u].valid_end(); }
 
-        auto iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
+        iterator iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
 
         bool exists(Vertex v) { return iterator_to(v) != end(); }
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -21,13 +21,18 @@ template <typename E> struct Matrix {
     class NeighborView {
       public:
         using iterator = typename BlockState<E>::iterator;
+        using const_iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::proxy;
 
         NeighborView(Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
 
         iterator begin() { return m_g->m_vertices[m_u].begin(); }
 
+        const_iterator cbegin() const { return m_g->m_vertices[m_u].cbegin(); }
+
         iterator end() { return m_g->m_vertices[m_u].valid_end(); }
+
+        const_iterator cend() const { return m_g->m_vertices[m_u].cvalid_end(); }
 
         iterator iterator_to(Vertex v) { return m_g->m_vertices[m_u].iterator_to(v); }
 
@@ -73,9 +78,9 @@ template <typename E> struct Matrix {
 
         ConstNeighborView(const Matrix* g, Vertex u) : m_g{g}, m_u{u} {}
 
-        iterator begin() const { return m_g->m_vertices[m_u].begin(); }
+        iterator begin() const { return m_g->m_vertices[m_u].cbegin(); }
 
-        iterator end() const { return m_g->m_vertices[m_u].valid_end(); }
+        iterator end() const { return m_g->m_vertices[m_u].cvalid_end(); }
 
         iterator iterator_to(Vertex v) const { return m_g->m_vertices[m_u].iterator_to(v); }
 

--- a/include/dhb/dynamic_hashed_blocks.h
+++ b/include/dhb/dynamic_hashed_blocks.h
@@ -76,7 +76,7 @@ template <typename E> struct Matrix {
         using iterator = typename BlockState<E>::const_iterator;
         using proxy = typename BlockState<E>::const_proxy;
 
-        ConstNeighborView(const Matrix* g, Vertex u) : m_graph{g}, m_source{u} {}
+        ConstNeighborView(Matrix const* g, Vertex u) : m_graph{g}, m_source{u} {}
 
         iterator begin() const { return m_graph->m_vertices[m_source].cbegin(); }
 

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -61,6 +61,7 @@ TEST_CASE("Matrix") {
         Matrix<EdgeData> m(std::move(edges));
         // N(89) = 13, 31
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
+        CHECK(nv.source() == 89);
         CHECK(nv.degree() == 3);
         CHECK(nv.exists(13));
         CHECK(nv.exists(31));
@@ -107,6 +108,7 @@ TEST_CASE("Matrix") {
         Matrix<EdgeData> const m(std::move(edges));
         // N(89) = 13, 31
         Matrix<EdgeData>::ConstNeighborView nv = m.neighbors(89);
+        CHECK(nv.source() == 89);
         CHECK(nv.degree() == 3);
         CHECK(nv.exists(13));
         CHECK(nv.exists(31));

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -67,14 +67,14 @@ TEST_CASE("Matrix") {
         CHECK(nv.exists(31));
         CHECK(nv.exists(86));
 
-        auto n89 = nv.begin();
+        auto n89 = nv.cbegin();
         CHECK(n89 != nv.end());
 
         // yes, we assume an order here
         CHECK(n89->vertex() == 13);
-        CHECK(++n89 != nv.end());
+        CHECK(++n89 != nv.cend());
         CHECK(n89->vertex() == 31);
-        CHECK(++n89 != nv.end());
+        CHECK(++n89 != nv.cend());
         CHECK(n89->vertex() == 86);
 
         auto n31 = nv.iterator_to(31);

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -89,6 +89,36 @@ TEST_CASE("Matrix") {
         CHECK(nv.exists(14));
     }
 
+    SECTION("NeighborView, copy constructor") {
+        Matrix<EdgeData> m(std::move(edges));
+        // N(89) = 13, 31
+        Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
+
+        Matrix<EdgeData>::NeighborView nv_copy{nv};
+
+        CHECK(nv_copy.source() == nv.source());
+        CHECK(nv_copy.degree() == nv.degree());
+        CHECK(nv_copy.exists(13) == nv.exists(13));
+        CHECK(nv_copy.exists(31) == nv.exists(31));
+        CHECK(nv_copy.exists(86) == nv.exists(86));
+    }
+
+    SECTION("NeighborView, copy assignment") {
+        Matrix<EdgeData> m(std::move(edges));
+        // N(89) = 13, 31
+        Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
+        Matrix<EdgeData>::NeighborView nv_other = m.neighbors(1);
+        REQUIRE(nv_other.degree() > 1);
+
+        nv_other = nv;
+
+        CHECK(nv_other.source() == nv.source());
+        CHECK(nv_other.degree() == nv.degree());
+        CHECK(nv_other.exists(13) == nv.exists(13));
+        CHECK(nv_other.exists(31) == nv.exists(31));
+        CHECK(nv_other.exists(86) == nv.exists(86));
+    }
+
     SECTION("change target vertex of edge") {
         Matrix<EdgeData> m(std::move(edges));
         constexpr Vertex source = 89;

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Matrix") {
         Matrix<EdgeData> m(std::move(edges));
         // N(89) = 13, 31
         Matrix<EdgeData>::NeighborView nv = m.neighbors(89);
-        Matrix<EdgeData>::NeighborView nv_other = m.neighbors(1);
+        Matrix<EdgeData>::NeighborView nv_other = m.neighbors(186);
         REQUIRE(nv_other.degree() > 1);
 
         nv_other = nv;


### PR DESCRIPTION
The Neighbor View Classes are an important tool to iterate over neighbors N(u) of vertex u. The usage of it is fairly simple, yet lagged the feature of returning the vertex u as the _source of neighborhood N(u)_. A simple get function `source()` has been added to the class incl. tests. 

As a finish you will find explicit type declarations for `iterator` and (east) `const` correctness as well as the possibility to return `const` iterators for both `NeighborView` and `ConstNeighborView`.

Added:
- [x] tests for copy constructor & copy assignment operator