### PR TITLE
CMake Readme Fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ git submodule update --init --recursive
 You can then build the tests by setting the CMake option `DHB_TEST` to `On`.
 
 ```
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DDHB_TEST=On ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DDHB_BUILD_TESTS=On ..
 ninja
 ```
 


### PR DESCRIPTION
Now we're using the right name of the DHB test target in the readme.